### PR TITLE
Fix: failed to run main.py using python 3.11.9 msvc 64 bit version.

### DIFF
--- a/main.py
+++ b/main.py
@@ -130,7 +130,7 @@ def main():
 
   download_and_patch(profile.ver, paths, profile.info)
 
-  os.environ['PATH'] = f'{paths.x_prefix}/bin:{os.environ['PATH']}'
+  os.environ['PATH'] = f'{paths.x_prefix}/bin:{os.environ["PATH"]}'
 
   if not config.no_cross:
     build_cross_compiler(profile.ver, paths, profile.info, config)

--- a/module/cross_compiler.py
+++ b/module/cross_compiler.py
@@ -136,7 +136,7 @@ def _gcc(ver: str, paths: ProjectPaths, info: ProfileInfo, jobs: int):
 
   configure('gcc', build_dir, [
     f'--prefix={paths.x_prefix}',
-    f'--libexecdir={paths.x_prefix / 'lib'}',
+    f'--libexecdir={paths.x_prefix / "lib"}',
     f'--with-gcc-major-version-only',
     f'--target={info.target}',
     # static build

--- a/module/mingw_toolchain.py
+++ b/module/mingw_toolchain.py
@@ -203,7 +203,7 @@ def _gcc(ver: str, paths: ProjectPaths, info: ProfileInfo, jobs: int):
 
   configure('gcc', build_dir, [
     f'--prefix={paths.prefix}',
-    f'--libexecdir={paths.prefix / 'lib'}',
+    f'--libexecdir={paths.prefix / "lib"}',
     f'--with-gcc-major-version-only',
     f'--target={info.target}',
     f'--host={info.target}',


### PR DESCRIPTION
When I tried to run main.py under cmd, I got the the errors in the attached pic.

That is , use "\'" in the single-quoted foramt-literals.

This patch fixes them.

![MEO(FT `9A_)ITL0_~ 3D2K](https://github.com/user-attachments/assets/b2b0ec41-a381-4511-bccf-0760de1b6564)
